### PR TITLE
Select component

### DIFF
--- a/packages/swarm-components/src/Select.jsx
+++ b/packages/swarm-components/src/Select.jsx
@@ -1,0 +1,56 @@
+// @flow
+import * as React from 'react';
+import Icon from './Icon';
+
+type Props = React.ElementConfig<HTMLSelectElement> & {
+    disabled?: boolean,
+	error?: string,
+	helperText?: string,
+    id?: string,
+	label?: string,
+	name?: string,
+	required?: boolean,
+};
+
+const Select = (props: Props) => {
+	const {
+        disabled,
+		error,
+        helperText,
+        id,
+		label,
+        name,
+		required,
+		...other
+	} = props;
+
+	return (
+		<div data-swarm-select={disabled ? 'disabled' : 'default'}>
+			{label && (
+				<label
+					htmlFor={name}
+					data-requiredtext="*"
+				>
+					{label}
+				</label>
+            )}
+
+			{helperText && (
+                <div>
+                    {helperText}
+                </div>
+            )}
+
+            <select
+                name={name}
+                id={id || name}
+                required={Boolean(required)}
+                {...other}
+            />
+
+            <Icon shape="chevron-down" size="xs" />
+		</div>
+	);
+};
+
+export default Select;


### PR DESCRIPTION
This copies over the Select component from meetup-web-components, removes an css classNames and corresponding logic, removes the `withErrorList` HOC, and adds a root level data attribute.

*Note*: I'm assuming we don't want to use the `withErrorList` HOC, so for now I'm assuming that the `error` prop is a string. I can change this if it's not the case. 