### PR TITLE
fix: adding swarm styles to markdown nodes

### DIFF
--- a/packages/swarm-docs/gatsby-config.js
+++ b/packages/swarm-docs/gatsby-config.js
@@ -34,4 +34,4 @@ module.exports = {
     },
     'gatsby-plugin-offline',
   ],
-}
+};

--- a/packages/swarm-docs/src/components/layout-mdx.js
+++ b/packages/swarm-docs/src/components/layout-mdx.js
@@ -19,11 +19,18 @@ const PreComponent = ({ className, ...props }) => {
   )
 }
 
+// apply swarm classnames to classes used in markdown
+const H1 = props => <h1 className="text--display" {...props}/>
+const H2 = props => <h2 className="text--pageTitle" {...props}/>
+const H3 = props => <h3 className="text--big" {...props}/>
+const P = props => <p className="text--body" {...props}/>
+const A = props => <a className="text--link" {...props}/>
+
 export default class MDXLayout extends React.Component {
   render() {
     return (
       <Layout>
-        <MDXProvider components={{ pre: PreComponent }}>
+        <MDXProvider components={{ pre: PreComponent, h1: H1, h2: H2, h3: H3, p: P, a: A }}>
           {this.props.children}
         </MDXProvider>
       </Layout>

--- a/packages/swarm-docs/src/pages/Button.mdx
+++ b/packages/swarm-docs/src/pages/Button.mdx
@@ -22,7 +22,7 @@ This is a button for swarm 2
 
 <Button bordered>Click</Button>
 
-# Inverted
+## Inverted
 <div style={{backgroundColor: 'black'}}>
     <Button inverted>Inverted</Button>
 </div>
@@ -30,17 +30,16 @@ This is a button for swarm 2
     <Button inverted>Inverted</Button>
 </div>
 
-# Button V2
+## Button V2
 <Button primary icon='arrow-right' right>Hello</Button>
 <Button primary icon='arrow-right'>Hello</Button>
-<Button primary icon='arrow-right' />
 
-# Icon
+## Icon
 <Icon shape="arrow-right" />
 
-# Button V1
+## Button V1
 <button class="button button-primary">old</button>
 
-# Interactive
+## Interactive
 
 <Example />


### PR DESCRIPTION
Adding classes to use the design system styles in text rendered from markdown