### PR TITLE
Fix disabled button

### DIFF
--- a/packages/swarm-components/src/Button.jsx
+++ b/packages/swarm-components/src/Button.jsx
@@ -98,10 +98,6 @@ const Button = (props: Props): React.Element<'button'> => {
 		...rest
 	} = props;
 
-	if (props.disabled && props.onClick) {
-		delete props.onClick;
-	}
-
 	const buttonType = getButtonType(props);
 
 	return (


### PR DESCRIPTION
## Goals

- [x] Passing both `onClick` and `disabled` to a Button should not result in a `TypeError`.

We don't have to delete `onClick` in the event the Button is disabled. This is because the Button will end up with a disabled attribute on it. That's enough to make it ignore clicks.