### PR TITLE
Fix Flow errors in Radio.jsx

### DIFF
--- a/packages/swarm-components/src/Radio.jsx
+++ b/packages/swarm-components/src/Radio.jsx
@@ -31,11 +31,11 @@ export type Props = {
    * Use children as an alternative to the `label` prop for more complex input labels.
    * The `label` prop will override children.
    */
-  children?: React.ReactElement<*>,
+  children?: React.Node,
 };
 
 // Can not inline css vars as color to Icon. Gray 5 icon fill on disbaled
-const Radio = (props: Props): React.ReactElement<'label'> => {
+const Radio = (props: Props): React.Element<'label'> => {
   const {
     checked,
     label,


### PR DESCRIPTION
```sadaf: ~/git_repo/swarm-ui/packages/swarm-components [master] $ yarn flow
yarn run v1.9.4
$ /Users/sadaf/git_repo/swarm-ui/packages/swarm-components/node_modules/.bin/flow
Launching Flow server for /Users/sadaf/git_repo/swarm-ui/packages/swarm-components
Spawned flow server (pid=51041)
Logs will go to /private/tmp/flow/zSUserszSsadafzSgit_repozSswarm-uizSpackageszSswarm-components.log
Monitor logs will go to /private/tmp/flow/zSUserszSsadafzSgit_repozSswarm-uizSpackageszSswarm-components.monitor_log
Error ┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈ src/Radio.jsx:34:20

Cannot get React.ReactElement because property ReactElement is missing in module react [1].

 [1]  2│ import * as React from 'react';
       :
     31│    * Use children as an alternative to the `label` prop for more complex input labels.
     32│    * The `label` prop will override children.
     33│    */
     34│   children?: React.ReactElement<*>,
     35│ };
     36│
     37│ // Can not inline css vars as color to Icon. Gray 5 icon fill on disbaled


Error ┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈ src/Radio.jsx:38:37

Cannot get React.ReactElement because property ReactElement is missing in module react [1].

 [1]  2│ import * as React from 'react';
       :
     35│ };
     36│
     37│ // Can not inline css vars as color to Icon. Gray 5 icon fill on disbaled
     38│ const Radio = (props: Props): React.ReactElement<'label'> => {
     39│   const {
     40│     checked,
     41│     label,



Found 2 errors
error Command failed with exit code 2.
info Visit https://yarnpkg.com/en/docs/cli/run for documentation about this command.```