### PR TITLE
Textarea component causing unit test errors in MWC

### DIFF
--- a/packages/swarm-components/lib/Radio.js
+++ b/packages/swarm-components/lib/Radio.js
@@ -98,11 +98,8 @@ Radio.__docgenInfo = {
     "children": {
       "required": false,
       "flowType": {
-        "name": "ReactReactElement",
-        "raw": "React.ReactElement<*>",
-        "elements": [{
-          "name": "unknown"
-        }]
+        "name": "ReactNode",
+        "raw": "React.Node"
       },
       "description": "Use children as an alternative to the `label` prop for more complex input labels.\nThe `label` prop will override children."
     }

--- a/packages/swarm-components/lib/Toggle.js
+++ b/packages/swarm-components/lib/Toggle.js
@@ -25,8 +25,10 @@ var FILLS = {
 };
 
 var Toggle = function Toggle(props) {
-  var checked = props.checked,
-      disabled = props.disabled,
+  var _props$checked = props.checked,
+      checked = _props$checked === void 0 ? false : _props$checked,
+      _props$disabled = props.disabled,
+      disabled = _props$disabled === void 0 ? false : _props$disabled,
       rest = _objectWithoutProperties(props, ["checked", "disabled"]);
 
   var checkedStatus = checked ? 'checked' : 'unchecked';

--- a/packages/swarm-components/src/Textarea.jsx
+++ b/packages/swarm-components/src/Textarea.jsx
@@ -2,25 +2,36 @@
 import * as React from 'react';
 
 type Props = {
-    disabeld?: boolean,
+    /**
+     * Whether the textarea should be interactive.
+     */
+    disabled?: boolean,
+    /**
+     * Whether the textarea renders an error state.
+     */
     error?: boolean,
+    /**
+     * Value for textarea.
+     */
     value?: string
 }
 
-const getTextareaStatus = (props: Props) => {
-    let status = 'default';
-    if (props.error) status = 'error';
-    if (props.disabeld) status = 'disabled';
-    return status;
-}
+const getTextareaStatus = (props: Props): string => {
+    return props.disabled ? 'disabled' : (props.error ? 'error' : 'default');
+};
 
 const getCharacterCount = (value: string = '') => value.length;
 
-export const Textarea = (props: Props) => {
+const Textarea = (props: Props): React.Element<'textarea'> => {
 
-    console.log('textarea char count', getCharacterCount(props.value))
+    console.log('textarea char count', getCharacterCount(props.value));
 
-    return <textarea data-swarm-textarea={getTextareaStatus(props)} {...props} />
-}
+    return (
+        <textarea
+            data-swarm-textarea={getTextareaStatus(props)}
+            {...props}
+        />
+    );
+};
 
 export default Textarea;


### PR DESCRIPTION
There are a bunch of unit test errors in the base migration branch in MWC:

```
 FAIL  src/forms/button.test.jsx
  ● Test suite failed to run

    Cannot find module './Textarea' from 'index.js'

      at Resolver.resolveModule (node_modules/jest-resolve/build/index.js:221:17)
      at Object.<anonymous> (node_modules/@meetup/swarm-components/lib/index.js:79:40)

 FAIL  src/forms/togglePill.test.jsx
  ● Test suite failed to run

    Cannot find module './Textarea' from 'index.js'

      at Resolver.resolveModule (node_modules/jest-resolve/build/index.js:221:17)
      at Object.<anonymous> (node_modules/@meetup/swarm-components/lib/index.js:79:40)

 FAIL  src/interactive/accordionPanelGroup.test.jsx
  ● Test suite failed to run

    Cannot find module './Textarea' from 'index.js'

      at Resolver.resolveModule (node_modules/jest-resolve/build/index.js:221:17)
      at Object.<anonymous> (node_modules/@meetup/swarm-components/lib/index.js:79:40)

 FAIL  src/interactive/dropdown.test.jsx
  ● Test suite failed to run

    Cannot find module './Textarea' from 'index.js'

      at Resolver.resolveModule (node_modules/jest-resolve/build/index.js:221:17)
      at Object.<anonymous> (node_modules/@meetup/swarm-components/lib/index.js:79:40)

 FAIL  src/navigation/Nav.test.jsx
  ● Test suite failed to run

    Cannot find module './Textarea' from 'index.js'

      at Resolver.resolveModule (node_modules/jest-resolve/build/index.js:221:17)
      at Object.<anonymous> (node_modules/@meetup/swarm-components/lib/index.js:79:40)

 FAIL  src/interactive/tooltip.test.jsx
  ● Test suite failed to run

    Cannot find module './Textarea' from 'index.js'

      at Resolver.resolveModule (node_modules/jest-resolve/build/index.js:221:17)
      at Object.<anonymous> (node_modules/@meetup/swarm-components/lib/index.js:79:40)

 FAIL  src/interactive/modal.test.js
  ● Test suite failed to run

    Cannot find module './Textarea' from 'index.js'

      at Resolver.resolveModule (node_modules/jest-resolve/build/index.js:221:17)
      at Object.<anonymous> (node_modules/@meetup/swarm-components/lib/index.js:79:40)

 FAIL  src/interactive/accordionPanel.test.jsx
  ● Test suite failed to run

    Cannot find module './Textarea' from 'index.js'

      at Resolver.resolveModule (node_modules/jest-resolve/build/index.js:221:17)
      at Object.<anonymous> (node_modules/@meetup/swarm-components/lib/index.js:79:40)

 FAIL  src/interactive/AdminBar.test.jsx
  ● Test suite failed to run

    Cannot find module './Textarea' from 'index.js'

      at Resolver.resolveModule (node_modules/jest-resolve/build/index.js:221:17)
      at Object.<anonymous> (node_modules/@meetup/swarm-components/lib/index.js:79:40)

 FAIL  src/interactive/toast.test.jsx
  ● Test suite failed to run

    Cannot find module './Textarea' from 'index.js'

      at Resolver.resolveModule (node_modules/jest-resolve/build/index.js:221:17)
      at Object.<anonymous> (node_modules/@meetup/swarm-components/lib/index.js:79:40)

 FAIL  src/navigation/components/dashboard/DashboardDropdown.test.jsx
  ● Test suite failed to run

    Cannot find module './Textarea' from 'index.js'

      at Resolver.resolveModule (node_modules/jest-resolve/build/index.js:221:17)
      at Object.<anonymous> (node_modules/@meetup/swarm-components/lib/index.js:79:40)

 FAIL  src/forms/redux-form/numberInput.test.jsx
  ● Test suite failed to run

    Cannot find module './Textarea' from 'index.js'

      at Resolver.resolveModule (node_modules/jest-resolve/build/index.js:221:17)
      at Object.<anonymous> (node_modules/@meetup/swarm-components/lib/index.js:79:40)

 FAIL  src/forms/redux-form/checkbox.test.jsx
  ● Test suite failed to run

    Cannot find module './Textarea' from 'index.js'

      at Resolver.resolveModule (node_modules/jest-resolve/build/index.js:221:17)
      at Object.<anonymous> (node_modules/@meetup/swarm-components/lib/index.js:79:40)

 FAIL  src/forms/toggleSwitch.test.jsx
  ● Test suite failed to run

    Cannot find module './Textarea' from 'index.js'

      at Resolver.resolveModule (node_modules/jest-resolve/build/index.js:221:17)
      at Object.<anonymous> (node_modules/@meetup/swarm-components/lib/index.js:79:40)

 FAIL  src/forms/typeahead.test.jsx
  ● Test suite failed to run

    Cannot find module './Textarea' from 'index.js'

      at Resolver.resolveModule (node_modules/jest-resolve/build/index.js:221:17)
      at Object.<anonymous> (node_modules/@meetup/swarm-components/lib/index.js:79:40)

 FAIL  src/forms/checkbox.test.jsx
  ● Test suite failed to run

    Cannot find module './Textarea' from 'index.js'

      at Resolver.resolveModule (node_modules/jest-resolve/build/index.js:221:17)
      at Object.<anonymous> (node_modules/@meetup/swarm-components/lib/index.js:79:40)

 FAIL  src/forms/redux-form/togglePill.test.jsx
  ● Test suite failed to run

    Cannot find module './Textarea' from 'index.js'

      at Resolver.resolveModule (node_modules/jest-resolve/build/index.js:221:17)
      at Object.<anonymous> (node_modules/@meetup/swarm-components/lib/index.js:79:40)

 FAIL  src/forms/radioButton.test.jsx
  ● Test suite failed to run

    Cannot find module './Textarea' from 'index.js'

      at Resolver.resolveModule (node_modules/jest-resolve/build/index.js:221:17)
      at Object.<anonymous> (node_modules/@meetup/swarm-components/lib/index.js:79:40)

 FAIL  src/forms/radioButtonGroup.test.jsx
  ● Test suite failed to run

    Cannot find module './Textarea' from 'index.js'

      at Resolver.resolveModule (node_modules/jest-resolve/build/index.js:221:17)
      at Object.<anonymous> (node_modules/@meetup/swarm-components/lib/index.js:79:40)

...
```

I'm not inherently certain whats causing this as the component is correctly there, but I'm wondering if there are formatting and/or flow issues.