### PR TITLE
use PR number to avoid beta build number conflicts

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -13,6 +13,6 @@ ifeq ($(TRAVIS_PULL_REQUEST), false)
 	git checkout master
 	lerna publish --conventional-commits --yes -m "$$COMMIT_MESSAGE"
 else
-	lerna publish --conventional-commits --yes --canary --preid "pr.$(TRAVIS_PULL_REQUEST)" -m "$$COMMIT_MESSAGE"
+	lerna publish --conventional-commits --yes --canary --preid "pr.$(TRAVIS_PULL_REQUEST)" -m "$$COMMIT_MESSAGE" --force-publish
 endif
 endif

--- a/Makefile
+++ b/Makefile
@@ -14,6 +14,11 @@ ifeq ($(TRAVIS_PULL_REQUEST), false)
 	git checkout master
 	lerna publish --conventional-commits --yes -m "$$COMMIT_MESSAGE"
 else
-	lerna publish --conventional-commits --yes --canary --preid "pr.$(TRAVIS_PULL_REQUEST).$(TRAVIS_BUILD_NUMBER)" -m "$$COMMIT_MESSAGE" --force-publish
+	lerna publish \
+		--conventional-commits \
+		--yes \
+		--canary \
+		--preid "pr.$(TRAVIS_PULL_REQUEST).$(TRAVIS_BUILD_NUMBER)" \
+		-m "$$COMMIT_MESSAGE"
 endif
 endif

--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,8 @@ chore: Version %s built by Travis CI
 $(TRAVIS_BUILD_WEB_URL)
 [skip ci]
 endef
-export COMMIT_MESSAGE
+
+export COMMIT_MESSAGE # make this value available as env var
 
 publish:
 	git remote set-url origin https://muptravis:$(GITHUB_TOKEN)@github.com/$(TRAVIS_REPO_SLUG).git

--- a/Makefile
+++ b/Makefile
@@ -14,6 +14,6 @@ ifeq ($(TRAVIS_PULL_REQUEST), false)
 	git checkout master
 	lerna publish --conventional-commits --yes -m "$$COMMIT_MESSAGE"
 else
-	lerna publish --conventional-commits --yes --canary --preid "pr.$(TRAVIS_PULL_REQUEST)" -m "$$COMMIT_MESSAGE" --force-publish
+	lerna publish --conventional-commits --yes --canary --preid "pr.$(TRAVIS_PULL_REQUEST).$(TRAVIS_BUILD_NUMBER)" -m "$$COMMIT_MESSAGE" --force-publish
 endif
 endif

--- a/Makefile
+++ b/Makefile
@@ -13,6 +13,6 @@ ifeq ($(TRAVIS_PULL_REQUEST), false)
 	git checkout master
 	lerna publish --conventional-commits --yes -m "$$COMMIT_MESSAGE"
 else
-	lerna publish --conventional-commits --yes --canary --preid beta -m "$$COMMIT_MESSAGE"
+	lerna publish --conventional-commits --yes --canary --preid "pr.$(TRAVIS_PULL_REQUEST)" -m "$$COMMIT_MESSAGE"
 endif
 endif


### PR DESCRIPTION
This will need a couple iterations to see how it behaves in different situations (like, will the PR build start interfering with itself even if it's not interfering with other PR builds?), but changing `--preid` is definitely the right approach https://github.com/lerna/lerna/tree/master/commands/publish#--canary