### PR TITLE
Update font weights

### DIFF
--- a/packages/swarm-constants/build/css/variables.css
+++ b/packages/swarm-constants/build/css/variables.css
@@ -1,6 +1,6 @@
 /**
  * Do not edit directly
- * Generated on Fri, 12 Apr 2019 14:56:22 GMT
+ * Generated on Fri, 12 Apr 2019 15:03:45 GMT
  */
 
 :root {
@@ -45,8 +45,9 @@
  --font-size-display-2: 32px;
  --font-size-display-1: 42px;
  --font-weight-normal: 400;
- --font-weight-semi-bold: 500;
- --font-weight-bold: 600;
+ --font-weight-regular: 500;
+ --font-weight-semi-bold: 600;
+ --font-weight-bold: 700;
  --size-font-small: 0.75; /* the small size of the font */
  --size-font-medium: 1; /* the medium size of the font */
  --size-font-large: 2; /* the large size of the font */

--- a/packages/swarm-constants/build/scss/_variables.scss
+++ b/packages/swarm-constants/build/scss/_variables.scss
@@ -1,6 +1,6 @@
 /**
  * Do not edit directly
- * Generated on Fri, 12 Apr 2019 14:56:22 GMT
+ * Generated on Fri, 12 Apr 2019 15:03:45 GMT
  */
 
 $color_merlot: #7A1D47;
@@ -44,8 +44,9 @@ $font_size_display_3: 28px;
 $font_size_display_2: 32px;
 $font_size_display_1: 42px;
 $font_weight_normal: 400;
-$font_weight_semi_bold: 500;
-$font_weight_bold: 600;
+$font_weight_regular: 500;
+$font_weight_semi_bold: 600;
+$font_weight_bold: 700;
 $size_font_small: 0.75; /* the small size of the font */
 $size_font_medium: 1; /* the medium size of the font */
 $size_font_large: 2; /* the large size of the font */

--- a/packages/swarm-constants/properties/font/weight.json
+++ b/packages/swarm-constants/properties/font/weight.json
@@ -4,13 +4,15 @@
       "normal": {
         "value": "400"
       },
-      "semiBold": {
+      "regular": {
         "value": "500"
       },
-      "bold": {
+      "semiBold": {
         "value": "600"
+      },
+      "bold": {
+        "value": "700"
       }
     }
   }
 }
-


### PR DESCRIPTION
* Updated font weights in swarm-constants.
* No update is needed the swarm-styles. Those are already correct:
    * `text--display` is already bold: https://github.com/meetup/swarm-ui/blob/master/packages/swarm-styles/lib/type.css#L11
    * `text--pageTitle` is already bold: https://github.com/meetup/swarm-ui/blob/master/packages/swarm-styles/lib/type.css#L20
    * `text--big` is already semi-bold: https://github.com/meetup/swarm-ui/blob/master/packages/swarm-styles/lib/type.css#L33
    * `text--sectionTitle` is already semi-bold: https://github.com/meetup/swarm-ui/blob/master/packages/swarm-styles/lib/type.css#L41


The new `normal` font-weight in swarm-constants is not being used for anything at the moment. Should it be?