### PR TITLE
WP-1180: Char Count for TextInput

### DIFF
--- a/.prettierrc
+++ b/.prettierrc
@@ -3,6 +3,7 @@
 	"singleQuote": true,
 	"trailingComma": "es5",
 	"useTabs": true,
+	"semi": true,
 	"overrides": [
 		{
 			"files": "packages/swarm-styles/lib/**/**/*.css",

--- a/packages/swarm-components/src/TextInput.jsx
+++ b/packages/swarm-components/src/TextInput.jsx
@@ -1,7 +1,10 @@
 // @flow
 import * as React from 'react';
 import Icon from './Icon';
-import CharCount from './shared/CharCount';
+import CharCount, {
+	getRemainingCharacters,
+} from './shared/CharCount';
+import { getFormFieldState } from './utils/formUtils';
 
 const ICON_SIZES = Object.freeze({
 	XXS: 'xxs',
@@ -13,7 +16,7 @@ const ICON_SIZES = Object.freeze({
 	XXL: 'xxl',
 });
 
-type Props = {
+export type TextInputProps = {
 	/**
 	 * Whether the input should be interactive.
 	 */
@@ -60,7 +63,7 @@ type Props = {
 /**
  * @module TextInput
  */
-export const TextInput = (props: Props): React$Element<*> => {
+export const TextInput = (props: TextInputProps): React$Element<*> => {
 	const {
 		name,
 		error,
@@ -75,8 +78,11 @@ export const TextInput = (props: Props): React$Element<*> => {
 		...other
 	} = props;
 
+	const charLength = value.length;
+	const remainingCharacters = getRemainingCharacters(maxLength, charLength);
+
 	const wrapperState = iconShape ? 'icon' : 'default';
-	const inputState = disabled ? 'disabled' : error ? 'error' : 'default';
+	const inputState = getFormFieldState({ ...props, error: error || remainingCharacters < 0 });
 
 	return (
 		<div data-swarm-text-input-wrapper={wrapperState}>
@@ -95,7 +101,7 @@ export const TextInput = (props: Props): React$Element<*> => {
 					<Icon shape={iconShape} size={iconSize} aria-hidden={true} />
 				</span>
 			)}
-			{maxLength && <CharCount maxLength={maxLength} charLength={value.length} />}
+			{maxLength && <CharCount maxLength={maxLength} charLength={charLength} />}
 		</div>
 	);
 };

--- a/packages/swarm-components/src/TextInput.jsx
+++ b/packages/swarm-components/src/TextInput.jsx
@@ -1,9 +1,7 @@
 // @flow
 import * as React from 'react';
 import Icon from './Icon';
-import CharCount, {
-	getRemainingCharacters,
-} from './shared/CharCount';
+import CharCount, { hasMaxLengthError } from './shared/CharCount';
 import { getFormFieldState } from './utils/formUtils';
 
 const ICON_SIZES = Object.freeze({
@@ -78,11 +76,12 @@ export const TextInput = (props: TextInputProps): React$Element<*> => {
 		...other
 	} = props;
 
-	const charLength = value.length;
-	const remainingCharacters = getRemainingCharacters(maxLength, charLength);
-
 	const wrapperState = iconShape ? 'icon' : 'default';
-	const inputState = getFormFieldState({ ...props, error: error || remainingCharacters < 0 });
+	const charLength = value.length;
+	const inputState = getFormFieldState({
+		...props,
+		error: error || hasMaxLengthError(maxLength, charLength),
+	});
 
 	return (
 		<div data-swarm-text-input-wrapper={wrapperState}>

--- a/packages/swarm-components/src/TextInput.jsx
+++ b/packages/swarm-components/src/TextInput.jsx
@@ -1,7 +1,7 @@
 // @flow
 import * as React from 'react';
 import Icon from './Icon';
-import CharCount, { getRemainingCharacters } from './shared/CharCount';
+import CharCount from './shared/CharCount';
 
 const ICON_SIZES = Object.freeze({
 	XXS: 'xxs',
@@ -41,7 +41,7 @@ type Props = {
 	/**
 	 * Value of input.
 	 */
-	value: string,
+	value?: string,
 	/**
 	 * Name of icon to render in the input
 	 */
@@ -70,13 +70,13 @@ export const TextInput = (props: Props): React$Element<*> => {
 		id,
 		iconShape,
 		iconSize = 'xs',
+		value = '',
 		maxLength,
 		...other
 	} = props;
 
 	const wrapperState = iconShape ? 'icon' : 'default';
 	const inputState = disabled ? 'disabled' : error ? 'error' : 'default';
-	const remainingCharacters = getRemainingCharacters(maxLength, props.value);
 
 	return (
 		<div data-swarm-text-input-wrapper={wrapperState}>
@@ -87,6 +87,7 @@ export const TextInput = (props: Props): React$Element<*> => {
 				pattern={pattern}
 				disabled={disabled}
 				id={id}
+				value={value}
 				{...other}
 			/>
 			{iconShape && (
@@ -94,7 +95,7 @@ export const TextInput = (props: Props): React$Element<*> => {
 					<Icon shape={iconShape} size={iconSize} aria-hidden={true} />
 				</span>
 			)}
-			{maxLength && <CharCount>{remainingCharacters}</CharCount>}
+			{maxLength && <CharCount maxLength={maxLength} charLength={value.length} />}
 		</div>
 	);
 };

--- a/packages/swarm-components/src/TextInput.jsx
+++ b/packages/swarm-components/src/TextInput.jsx
@@ -1,104 +1,102 @@
 // @flow
 import * as React from 'react';
 import Icon from './Icon';
-import CharCount, {
-  getRemainingCharacters,
-} from './shared/CharCount';
+import CharCount, { getRemainingCharacters } from './shared/CharCount';
 
 const ICON_SIZES = Object.freeze({
-  XXS: 'xxs',
-  XS: 'xs',
-  S: 's',
-  M: 'm',
-  L: 'l',
-  XL: 'xl',
-  XXL: 'xxl',
+	XXS: 'xxs',
+	XS: 'xs',
+	S: 's',
+	M: 'm',
+	L: 'l',
+	XL: 'xl',
+	XXL: 'xxl',
 });
 
 type Props = {
-  /**
-   * Whether the input should be interactive.
-   */
-  disabled?: boolean,
-  /**
-   * Whether the field has an error.
-   */
-  error?: boolean,
-  /**
-   * An identifier for the input.
-   */
-  id: string,
-  /**
-   * Whether the input is a search field.
-   */
-  isSearch?: boolean,
-  /**
-   * Name for the input.
-   */
-  name: string,
-  /**
-   * A regular expression that the input's value is checked against on form submission.
-   */
-  pattern?: string,
-  /**
-   * Value of input.
-   */
-  value: string,
-  /**
-   * Name of icon to render in the input
-   */
-  iconShape?: string,
-  /**
-   * Optional size for icon if `iconShape` is provided.
-   * Default size is `xs`
-   */
-  iconSize?: $Values<typeof ICON_SIZES>,
-  /**
-   * max length of input field
-   */
-  maxLength?: string | number,
+	/**
+	 * Whether the input should be interactive.
+	 */
+	disabled?: boolean,
+	/**
+	 * Whether the field has an error.
+	 */
+	error?: boolean,
+	/**
+	 * An identifier for the input.
+	 */
+	id: string,
+	/**
+	 * Whether the input is a search field.
+	 */
+	isSearch?: boolean,
+	/**
+	 * Name for the input.
+	 */
+	name: string,
+	/**
+	 * A regular expression that the input's value is checked against on form submission.
+	 */
+	pattern?: string,
+	/**
+	 * Value of input.
+	 */
+	value: string,
+	/**
+	 * Name of icon to render in the input
+	 */
+	iconShape?: string,
+	/**
+	 * Optional size for icon if `iconShape` is provided.
+	 * Default size is `xs`
+	 */
+	iconSize?: $Values<typeof ICON_SIZES>,
+	/**
+	 * max length of input field
+	 */
+	maxLength?: string | number,
 };
 
 /**
  * @module TextInput
  */
 export const TextInput = (props: Props): React$Element<*> => {
-  const {
-    name,
-    error,
-    isSearch,
-    pattern,
-    disabled,
-    id,
-    iconShape,
-    iconSize = 'xs',
-    maxLength,
-    ...other
-  } = props;
+	const {
+		name,
+		error,
+		isSearch,
+		pattern,
+		disabled,
+		id,
+		iconShape,
+		iconSize = 'xs',
+		maxLength,
+		...other
+	} = props;
 
-  const wrapperState = iconShape ? 'icon' : 'default';
-  const inputState = disabled ? 'disabled' : error ? 'error' : 'default';
-  const remainingCharacters = getRemainingCharacters(maxLength, props.value);
+	const wrapperState = iconShape ? 'icon' : 'default';
+	const inputState = disabled ? 'disabled' : error ? 'error' : 'default';
+	const remainingCharacters = getRemainingCharacters(maxLength, props.value);
 
-  return (
-    <div data-swarm-text-input-wrapper={wrapperState}>
-      <input
-        data-swarm-text-input={inputState}
-        type={isSearch ? 'search' : 'text'}
-        name={name}
-        pattern={pattern}
-        disabled={disabled}
-        id={id}
-        {...other}
-      />
-      {iconShape && (
-        <span data-swarm-input-icon={iconShape}>
-          <Icon shape={iconShape} size={iconSize} aria-hidden={true} />
-        </span>
-      )}
-      {maxLength && <CharCount>{remainingCharacters}</CharCount>}
-    </div>
-  );
+	return (
+		<div data-swarm-text-input-wrapper={wrapperState}>
+			<input
+				data-swarm-text-input={inputState}
+				type={isSearch ? 'search' : 'text'}
+				name={name}
+				pattern={pattern}
+				disabled={disabled}
+				id={id}
+				{...other}
+			/>
+			{iconShape && (
+				<span data-swarm-input-icon={iconShape}>
+					<Icon shape={iconShape} size={iconSize} aria-hidden={true} />
+				</span>
+			)}
+			{maxLength && <CharCount>{remainingCharacters}</CharCount>}
+		</div>
+	);
 };
 
 export default TextInput;

--- a/packages/swarm-components/src/TextInput.jsx
+++ b/packages/swarm-components/src/TextInput.jsx
@@ -1,6 +1,9 @@
 // @flow
 import * as React from 'react';
 import Icon from './Icon';
+import CharCount, {
+  getRemainingCharacters,
+} from './shared/CharCount';
 
 const ICON_SIZES = Object.freeze({
   XXS: 'xxs',
@@ -50,6 +53,10 @@ type Props = {
    * Default size is `xs`
    */
   iconSize?: $Values<typeof ICON_SIZES>,
+  /**
+   * max length of input field
+   */
+  maxLength?: string | number,
 };
 
 /**
@@ -65,11 +72,13 @@ export const TextInput = (props: Props): React$Element<*> => {
     id,
     iconShape,
     iconSize = 'xs',
+    maxLength,
     ...other
   } = props;
 
   const wrapperState = iconShape ? 'icon' : 'default';
   const inputState = disabled ? 'disabled' : error ? 'error' : 'default';
+  const remainingCharacters = getRemainingCharacters(maxLength, props.value);
 
   return (
     <div data-swarm-text-input-wrapper={wrapperState}>
@@ -87,6 +96,7 @@ export const TextInput = (props: Props): React$Element<*> => {
           <Icon shape={iconShape} size={iconSize} aria-hidden={true} />
         </span>
       )}
+      {maxLength && <CharCount>{remainingCharacters}</CharCount>}
     </div>
   );
 };

--- a/packages/swarm-components/src/TextInput.jsx
+++ b/packages/swarm-components/src/TextInput.jsx
@@ -54,7 +54,7 @@ type Props = {
 	/**
 	 * max length of input field
 	 */
-	maxLength?: string | number,
+	maxLength?: number,
 };
 
 /**

--- a/packages/swarm-components/src/TextInput.test.jsx
+++ b/packages/swarm-components/src/TextInput.test.jsx
@@ -3,19 +3,77 @@ import { shallow } from 'enzyme';
 import TextInput from './TextInput';
 
 describe('TextInput', () => {
-    const mockOnChange = jest.fn();
+	const mockOnChange = jest.fn();
 
 	const testCases = [
-		['Default (empty)', <TextInput key="1" id="default" name="default" value="" />],
-		['Default (value)', <TextInput key="2" id="default" name="default" value="foo" />],
-		['Disabled', <TextInput key="3" id="disabled" name="disabled" value="" disabled />],
+		[
+			'Default (empty)',
+			<TextInput key="1" id="default" name="default" value="" />,
+		],
+		[
+			'Default (value)',
+			<TextInput key="2" id="default" name="default" value="foo" />,
+		],
+		[
+			'Disabled',
+			<TextInput key="3" id="disabled" name="disabled" value="" disabled />,
+		],
 		['Error', <TextInput key="4" id="error" name="error" value="" error />],
-		['isSearch', <TextInput key="5" id="isSearch" name="isSearch" value="" isSearch />],
-        ['Pattern', <TextInput key="6" id="pattern" name="pattern" value="" pattern="[A-Za-z]{3}" />],
-        ['onChange', <TextInput key="7" id="onChange" name="onChange" value="" onChange={mockOnChange} />],
-        ['Icon', <TextInput key="8" id="icon" name="icon" value="" iconShape="location-pin" />],
-        ['Icon (custom size)', <TextInput key="9" id="iconsize" name="iconsize" value="" iconShape="location-pin" iconSize="m" />],
-		['maxLength (char count)', <TextInput key="10" id="maxLength" name="maxLength" value="foo fooo" maxLength="20"/>],
+		[
+			'isSearch',
+			<TextInput key="5" id="isSearch" name="isSearch" value="" isSearch />,
+		],
+		[
+			'Pattern',
+			<TextInput
+				key="6"
+				id="pattern"
+				name="pattern"
+				value=""
+				pattern="[A-Za-z]{3}"
+			/>,
+		],
+		[
+			'onChange',
+			<TextInput
+				key="7"
+				id="onChange"
+				name="onChange"
+				value=""
+				onChange={mockOnChange}
+			/>,
+		],
+		[
+			'Icon',
+			<TextInput
+				key="8"
+				id="icon"
+				name="icon"
+				value=""
+				iconShape="location-pin"
+			/>,
+		],
+		[
+			'Icon (custom size)',
+			<TextInput
+				key="9"
+				id="iconsize"
+				name="iconsize"
+				value=""
+				iconShape="location-pin"
+				iconSize="m"
+			/>,
+		],
+		[
+			'maxLength (char count)',
+			<TextInput
+				key="10"
+				id="maxLength"
+				name="maxLength"
+				value="foo fooo"
+				maxLength="20"
+			/>,
+		],
 	];
 
 	test.each(testCases)('Snapshot: %s', (description, element) => {

--- a/packages/swarm-components/src/TextInput.test.jsx
+++ b/packages/swarm-components/src/TextInput.test.jsx
@@ -71,7 +71,7 @@ describe('TextInput', () => {
 				id="maxLength"
 				name="maxLength"
 				value="foo fooo"
-				maxLength="20"
+				maxLength={20}
 			/>,
 		],
 	];

--- a/packages/swarm-components/src/TextInput.test.jsx
+++ b/packages/swarm-components/src/TextInput.test.jsx
@@ -15,6 +15,7 @@ describe('TextInput', () => {
         ['onChange', <TextInput key="7" id="onChange" name="onChange" value="" onChange={mockOnChange} />],
         ['Icon', <TextInput key="8" id="icon" name="icon" value="" iconShape="location-pin" />],
         ['Icon (custom size)', <TextInput key="9" id="iconsize" name="iconsize" value="" iconShape="location-pin" iconSize="m" />],
+		['maxLength (char count)', <TextInput key="10" id="maxLength" name="maxLength" value="foo fooo" maxLength="20"/>],
 	];
 
 	test.each(testCases)('Snapshot: %s', (description, element) => {

--- a/packages/swarm-components/src/TextInput.test.jsx
+++ b/packages/swarm-components/src/TextInput.test.jsx
@@ -79,4 +79,12 @@ describe('TextInput', () => {
 	test.each(testCases)('Snapshot: %s', (description, element) => {
 		expect(shallow(element)).toMatchSnapshot();
 	});
+
+	describe('maxLength', () => {
+		it('should render error state when maxLength exceeded', () => {
+			const textInput = shallow(<TextInput name="foo" value="" maxLength={3} />);
+			textInput.setProps({value: "new value"});
+			expect(textInput.exists('[data-swarm-text-input="error"]')).toEqual(true);
+		});
+	});
 });

--- a/packages/swarm-components/src/Textarea.jsx
+++ b/packages/swarm-components/src/Textarea.jsx
@@ -2,6 +2,10 @@
 import * as React from 'react';
 import auto from 'autosize';
 
+import CharCount, {
+    getCharacterCount,
+} from './shared/CharCount';
+
 type Props = {
     /**
      * Resizes the height based on content
@@ -31,17 +35,9 @@ type Props = {
 
 type State = {};
 
-type CharProps = {
-    children?: React.Node
-}
-
 export const getTextareaStatus = (props: Props): string => {
     return props.disabled ? 'disabled' : (props.error ? 'error' : 'default');
 };
-
-export const getCharacterCount = (value: string = '') => value.length;
-
-export const CharCount = (props: CharProps) => <p data-swarm-textarea-char-count className="text--tiny" {...props} />;
 
 
 class Textarea extends React.Component<Props, State> {

--- a/packages/swarm-components/src/Textarea.jsx
+++ b/packages/swarm-components/src/Textarea.jsx
@@ -2,83 +2,85 @@
 import * as React from 'react';
 import auto from 'autosize';
 
-import CharCount, {
-    getRemainingCharacters,
-} from './shared/CharCount';
+import CharCount, { hasMaxLengthError } from './shared/CharCount';
 
 import { getFormFieldState } from './utils/formUtils';
 
 export type TextareaProps = {
-    /**
-     * Resizes the height based on content
-     */
-    autosize?: boolean,
-    /**
-     * Whether the textarea should be interactive.
-     */
-    disabled?: boolean,
-    /**
-     * Whether the textarea renders an error state.
-     */
-    error?: boolean,
-    /**
-     * Value for textarea.
-     */
-    name: string,
-    /**
-     * Name for the input.
-     */
-    value?: string,
-    /**
-     * max length of input field
-     */
-    maxLength?: number,
-}
+	/**
+	 * Resizes the height based on content
+	 */
+	autosize?: boolean,
+	/**
+	 * Whether the textarea should be interactive.
+	 */
+	disabled?: boolean,
+	/**
+	 * Whether the textarea renders an error state.
+	 */
+	error?: boolean,
+	/**
+	 * Value for textarea.
+	 */
+	name: string,
+	/**
+	 * Name for the input.
+	 */
+	value?: string,
+	/**
+	 * max length of input field
+	 */
+	maxLength?: number,
+};
 
 type State = {};
 
 class Textarea extends React.Component<TextareaProps, State> {
-    textarea: ?HTMLTextAreaElement;
+	textarea: ?HTMLTextAreaElement;
 
 	componentDidMount() {
-        if (this.props.autosize) {
-            auto(this.textarea);
-        }
-    }
+		if (this.props.autosize) {
+			auto(this.textarea);
+		}
+	}
 
 	componentDidUpdate(prevProps: TextareaProps) {
-        if (this.props.value !== prevProps.value) {
-            auto.update(this.textarea);
-        }
-    }
+		if (this.props.value !== prevProps.value) {
+			auto.update(this.textarea);
+		}
+	}
 
-    render() {
-        // maxLength is removed because we want to allow for typing over the character limit
-        const {
-            maxLength,
-            autosize, // eslint-disable-line no-unused-vars
-            value = '',
-            ...other
-        } = this.props;
+	render() {
+		// maxLength is removed because we want to allow for typing over the character limit
+		const {
+			maxLength,
+			autosize, // eslint-disable-line no-unused-vars
+			value = '',
+			...other
+		} = this.props;
 
-        const charLength = value.length;
-        const remainingCharacters = getRemainingCharacters(maxLength, charLength);
-        const textareaState = getFormFieldState({ ...this.props, error: this.props.error || remainingCharacters < 0 });
+		const charLength = value.length;
+		const textareaState = getFormFieldState({
+			...this.props,
+			error: this.props.error || hasMaxLengthError(maxLength, charLength),
+		});
 
-        return (
-            <div data-swarm-textarea-wrapper>
-                <textarea
-                    value={value}
-                    data-swarm-textarea={textareaState}
-                    ref={textarea => {
-                        this.textarea = textarea;
-                    }}
-                    {...other}
-                />
-                {maxLength && <CharCount maxLength={maxLength} charLength={charLength} />}
-            </div>
-        );
-    };
-};
+		return (
+			<div data-swarm-textarea-wrapper>
+				<textarea
+					value={value}
+					data-swarm-textarea={textareaState}
+					ref={textarea => {
+						this.textarea = textarea;
+					}}
+					{...other}
+				/>
+				{maxLength && (
+					<CharCount maxLength={maxLength} charLength={charLength} />
+				)}
+			</div>
+		);
+	}
+}
 
 export default Textarea;

--- a/packages/swarm-components/src/Textarea.jsx
+++ b/packages/swarm-components/src/Textarea.jsx
@@ -3,7 +3,7 @@ import * as React from 'react';
 import auto from 'autosize';
 
 import CharCount, {
-    getCharacterCount,
+    getRemainingCharacters,
 } from './shared/CharCount';
 
 type Props = {
@@ -63,7 +63,7 @@ class Textarea extends React.Component<Props, State> {
             ...other
         } = this.props;
 
-        const remainingCharacters = (parseInt(maxLength, 10) - getCharacterCount(this.props.value));
+        const remainingCharacters = getRemainingCharacters(maxLength, this.props.value);
         const textareaStatus = getTextareaStatus({ ...this.props, error: this.props.error || remainingCharacters < 0 });
 
         return (
@@ -75,7 +75,7 @@ class Textarea extends React.Component<Props, State> {
                     }}
                     {...other}
                 />
-                { maxLength && <CharCount>{remainingCharacters}</CharCount>}
+                {maxLength && <CharCount>{remainingCharacters}</CharCount>}
             </div>
         );
     };

--- a/packages/swarm-components/src/Textarea.jsx
+++ b/packages/swarm-components/src/Textarea.jsx
@@ -6,7 +6,9 @@ import CharCount, {
     getRemainingCharacters,
 } from './shared/CharCount';
 
-type Props = {
+import { getFormFieldState } from './utils/formUtils';
+
+export type TextareaProps = {
     /**
      * Resizes the height based on content
      */
@@ -35,12 +37,7 @@ type Props = {
 
 type State = {};
 
-export const getTextareaStatus = (props: Props): string => {
-    return props.disabled ? 'disabled' : (props.error ? 'error' : 'default');
-};
-
-
-class Textarea extends React.Component<Props, State> {
+class Textarea extends React.Component<TextareaProps, State> {
     textarea: ?HTMLTextAreaElement;
 
 	componentDidMount() {
@@ -49,7 +46,7 @@ class Textarea extends React.Component<Props, State> {
         }
     }
 
-	componentDidUpdate(prevProps: Props) {
+	componentDidUpdate(prevProps: TextareaProps) {
         if (this.props.value !== prevProps.value) {
             auto.update(this.textarea);
         }
@@ -66,13 +63,13 @@ class Textarea extends React.Component<Props, State> {
 
         const charLength = value.length;
         const remainingCharacters = getRemainingCharacters(maxLength, charLength);
-        const textareaStatus = getTextareaStatus({ ...this.props, error: this.props.error || remainingCharacters < 0 });
+        const textareaState = getFormFieldState({ ...this.props, error: this.props.error || remainingCharacters < 0 });
 
         return (
             <div data-swarm-textarea-wrapper>
                 <textarea
                     value={value}
-                    data-swarm-textarea={textareaStatus}
+                    data-swarm-textarea={textareaState}
                     ref={textarea => {
                         this.textarea = textarea;
                     }}

--- a/packages/swarm-components/src/Textarea.jsx
+++ b/packages/swarm-components/src/Textarea.jsx
@@ -60,22 +60,25 @@ class Textarea extends React.Component<Props, State> {
         const {
             maxLength,
             autosize, // eslint-disable-line no-unused-vars
+            value = '',
             ...other
         } = this.props;
 
-        const remainingCharacters = getRemainingCharacters(maxLength, this.props.value);
+        const charLength = value.length;
+        const remainingCharacters = getRemainingCharacters(maxLength, charLength);
         const textareaStatus = getTextareaStatus({ ...this.props, error: this.props.error || remainingCharacters < 0 });
 
         return (
             <div data-swarm-textarea-wrapper>
                 <textarea
+                    value={value}
                     data-swarm-textarea={textareaStatus}
                     ref={textarea => {
                         this.textarea = textarea;
                     }}
                     {...other}
                 />
-                {maxLength && <CharCount>{remainingCharacters}</CharCount>}
+                {maxLength && <CharCount maxLength={maxLength} charLength={charLength} />}
             </div>
         );
     };

--- a/packages/swarm-components/src/Textarea.jsx
+++ b/packages/swarm-components/src/Textarea.jsx
@@ -30,7 +30,7 @@ type Props = {
     /**
      * max length of input field
      */
-    maxLength?: string | number,
+    maxLength?: number,
 }
 
 type State = {};

--- a/packages/swarm-components/src/Textarea.test.jsx
+++ b/packages/swarm-components/src/Textarea.test.jsx
@@ -41,5 +41,13 @@ describe('Textarea', () => {
 			textarea.instance().componentDidUpdate({value: "prev props values"});
 			expect(auto.update).toHaveBeenCalled();
 		});
-    });
+	});
+
+	describe('maxLength', () => {
+		it('should render error state when maxLength exceeded', () => {
+			const textarea = shallow(<Textarea name="foo" value="" maxLength={3} />);
+			textarea.setProps({value: "new value"});
+			expect(textarea.exists('[data-swarm-textarea="error"]')).toEqual(true);
+		});
+	});
 });

--- a/packages/swarm-components/src/Textarea.test.jsx
+++ b/packages/swarm-components/src/Textarea.test.jsx
@@ -1,8 +1,6 @@
 import React from 'react';
 import { shallow, mount } from 'enzyme';
-import Textarea, {
-	getTextareaStatus,
-} from './Textarea';
+import Textarea from './Textarea';
 import auto from 'autosize';
 
 // mock `auto` from autosize library
@@ -44,19 +42,4 @@ describe('Textarea', () => {
 			expect(auto.update).toHaveBeenCalled();
 		});
     });
-});
-
-describe('getTextareaStatus', () => {
-	it('returns disabled when props contain disabled=true', () => {
-		expect(getTextareaStatus({disabled: true})).toEqual('disabled');
-		expect(getTextareaStatus({disabled: true, error: true})).toEqual('disabled');
-	});
-
-	it('returns error when props contain error=true', () => {
-		expect(getTextareaStatus({error: true})).toEqual('error');
-	});
-
-	it('returns default when props do not contain disabled or error', () => {
-		expect(getTextareaStatus({})).toEqual('default');
-	});
 });

--- a/packages/swarm-components/src/Textarea.test.jsx
+++ b/packages/swarm-components/src/Textarea.test.jsx
@@ -2,11 +2,8 @@ import React from 'react';
 import { shallow, mount } from 'enzyme';
 import Textarea, {
 	getTextareaStatus,
-	getCharacterCount,
-	CharCount,
 } from './Textarea';
 import auto from 'autosize';
-import { isTryStatement } from '@babel/types';
 
 // mock `auto` from autosize library
 jest.mock('autosize', () => {
@@ -62,28 +59,4 @@ describe('getTextareaStatus', () => {
 	it('returns default when props do not contain disabled or error', () => {
 		expect(getTextareaStatus({})).toEqual('default');
 	});
-});
-
-describe('getCharacterCount', () => {
-	it('returns 0 when no argument provided', () => {
-		expect(getCharacterCount()).toEqual(0);
-	});
-
-	it('returns the length of a string', () => {
-		expect(getCharacterCount('')).toEqual(0);
-		expect(getCharacterCount('f')).toEqual(1);
-		expect(getCharacterCount('f234')).toEqual(4);
-		expect(getCharacterCount('ff ff ff')).toEqual(8);
-	});
-});
-
-describe('CharCount', () => {
-	const testCases = [
-		['Default', <CharCount key="0" />],
-		['with props', <CharCount key="1" className="foo" data-attribute="foo" />],
-	];
-
-	test.each(testCases)('Snapshot: %s', (description, element) => {
-		expect(shallow(element)).toMatchSnapshot();
-    });
 });

--- a/packages/swarm-components/src/Textarea.test.jsx
+++ b/packages/swarm-components/src/Textarea.test.jsx
@@ -21,7 +21,7 @@ describe('Textarea', () => {
 		['Default (value)', <Textarea key="1" value="foo" />],
 		['Disabled', <Textarea key="2" value="" disabled />],
 		['Error', <Textarea key="3" value="foo" error />],
-		['maxLength', <Textarea key="4" value="foo" maxLength />],
+		['maxLength', <Textarea key="4" value="foo" maxLength="20" />],
 		['autosize', <Textarea key="5" value="foo" autosize />],
 		['onChange', <Textarea key="6" value="" onChange={mockOnChange} />],
 	];

--- a/packages/swarm-components/src/Textarea.test.jsx
+++ b/packages/swarm-components/src/Textarea.test.jsx
@@ -21,7 +21,7 @@ describe('Textarea', () => {
 		['Default (value)', <Textarea key="1" value="foo" />],
 		['Disabled', <Textarea key="2" value="" disabled />],
 		['Error', <Textarea key="3" value="foo" error />],
-		['maxLength', <Textarea key="4" value="foo" maxLength="20" />],
+		['maxLength', <Textarea key="4" value="foo" maxLength={20} />],
 		['autosize', <Textarea key="5" value="foo" autosize />],
 		['onChange', <Textarea key="6" value="" onChange={mockOnChange} />],
 	];

--- a/packages/swarm-components/src/__snapshots__/TextInput.test.jsx.snap
+++ b/packages/swarm-components/src/__snapshots__/TextInput.test.jsx.snap
@@ -143,9 +143,10 @@ exports[`TextInput Snapshot: maxLength (char count) 1`] = `
     type="text"
     value="foo fooo"
   />
-  <CharCount>
-    12
-  </CharCount>
+  <CharCount
+    charLength={8}
+    maxLength={20}
+  />
 </div>
 `;
 

--- a/packages/swarm-components/src/__snapshots__/TextInput.test.jsx.snap
+++ b/packages/swarm-components/src/__snapshots__/TextInput.test.jsx.snap
@@ -132,6 +132,23 @@ exports[`TextInput Snapshot: isSearch 1`] = `
 </div>
 `;
 
+exports[`TextInput Snapshot: maxLength (char count) 1`] = `
+<div
+  data-swarm-text-input-wrapper="default"
+>
+  <input
+    data-swarm-text-input="default"
+    id="maxLength"
+    name="maxLength"
+    type="text"
+    value="foo fooo"
+  />
+  <CharCount>
+    12
+  </CharCount>
+</div>
+`;
+
 exports[`TextInput Snapshot: onChange 1`] = `
 <div
   data-swarm-text-input-wrapper="default"

--- a/packages/swarm-components/src/__snapshots__/Textarea.test.jsx.snap
+++ b/packages/swarm-components/src/__snapshots__/Textarea.test.jsx.snap
@@ -65,9 +65,10 @@ exports[`Textarea Snapshot: maxLength 1`] = `
     data-swarm-textarea="default"
     value="foo"
   />
-  <CharCount>
-    17
-  </CharCount>
+  <CharCount
+    charLength={3}
+    maxLength={20}
+  />
 </div>
 `;
 

--- a/packages/swarm-components/src/__snapshots__/Textarea.test.jsx.snap
+++ b/packages/swarm-components/src/__snapshots__/Textarea.test.jsx.snap
@@ -66,7 +66,7 @@ exports[`Textarea Snapshot: maxLength 1`] = `
     value="foo"
   />
   <CharCount>
-    NaN
+    17
   </CharCount>
 </div>
 `;

--- a/packages/swarm-components/src/__snapshots__/Textarea.test.jsx.snap
+++ b/packages/swarm-components/src/__snapshots__/Textarea.test.jsx.snap
@@ -1,20 +1,5 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`CharCount Snapshot: Default 1`] = `
-<p
-  className="text--tiny"
-  data-swarm-textarea-char-count={true}
-/>
-`;
-
-exports[`CharCount Snapshot: with props 1`] = `
-<p
-  className="foo"
-  data-attribute="foo"
-  data-swarm-textarea-char-count={true}
-/>
-`;
-
 exports[`Textarea Snapshot: Default (empty) 1`] = `
 <div
   data-swarm-textarea-wrapper={true}

--- a/packages/swarm-components/src/shared/CharCount.jsx
+++ b/packages/swarm-components/src/shared/CharCount.jsx
@@ -6,7 +6,7 @@ type CharProps = {
 };
 
 export const getRemainingCharacters = (maxLength: number, value: string = '') =>
-	parseInt(maxLength, 10) - value.length;
+	maxLength - value.length;
 
 const CharCount = (props: CharProps) => (
 	<p data-swarm-textarea-char-count className="text--tiny" {...props} />

--- a/packages/swarm-components/src/shared/CharCount.jsx
+++ b/packages/swarm-components/src/shared/CharCount.jsx
@@ -2,14 +2,24 @@
 import * as React from 'react';
 
 type CharProps = {
-	children?: React.Node,
+	maxLength: number,
+	charLength?: number,
 };
 
-export const getRemainingCharacters = (maxLength: number, value: string = '') =>
-	maxLength - value.length;
+export const getRemainingCharacters = (maxLength: number, charLength: number = 0) => maxLength - charLength;
 
-const CharCount = (props: CharProps) => (
-	<p data-swarm-textarea-char-count className="text--tiny" {...props} />
-);
+const CharCount = (props: CharProps) => {
+	const {
+		maxLength,
+		charLength = 0,
+		...other
+	} = props;
+
+	return (
+		<p data-swarm-textarea-char-count className="text--tiny" {...other}>
+			{getRemainingCharacters(maxLength, charLength)}
+		</p>
+	);
+};
 
 export default CharCount;

--- a/packages/swarm-components/src/shared/CharCount.jsx
+++ b/packages/swarm-components/src/shared/CharCount.jsx
@@ -5,7 +5,7 @@ type CharProps = {
     children?: React.Node
 }
 
-export const getCharacterCount = (value: string = '') => value.length;
+export const getRemainingCharacters = (maxLength: number, value: string = '') => (parseInt(maxLength, 10) - value.length);
 
 const CharCount = (props: CharProps) => <p data-swarm-textarea-char-count className="text--tiny" {...props} />;
 

--- a/packages/swarm-components/src/shared/CharCount.jsx
+++ b/packages/swarm-components/src/shared/CharCount.jsx
@@ -6,14 +6,18 @@ type CharProps = {
 	charLength?: number,
 };
 
-export const getRemainingCharacters = (maxLength: number, charLength: number = 0) => maxLength - charLength;
+export const getRemainingCharacters = (
+	maxLength: number,
+	charLength: number = 0
+): number => maxLength - charLength;
+
+export const hasMaxLengthError = (
+	maxLength: number,
+	charLength: number = 0
+): boolean => charLength > maxLength;
 
 const CharCount = (props: CharProps) => {
-	const {
-		maxLength,
-		charLength = 0,
-		...other
-	} = props;
+	const { maxLength, charLength = 0, ...other } = props;
 
 	return (
 		<p data-swarm-textarea-char-count className="text--tiny" {...other}>

--- a/packages/swarm-components/src/shared/CharCount.jsx
+++ b/packages/swarm-components/src/shared/CharCount.jsx
@@ -1,0 +1,12 @@
+// @flow
+import * as React from 'react';
+
+type CharProps = {
+    children?: React.Node
+}
+
+export const getCharacterCount = (value: string = '') => value.length;
+
+const CharCount = (props: CharProps) => <p data-swarm-textarea-char-count className="text--tiny" {...props} />;
+
+export default CharCount;

--- a/packages/swarm-components/src/shared/CharCount.jsx
+++ b/packages/swarm-components/src/shared/CharCount.jsx
@@ -2,11 +2,14 @@
 import * as React from 'react';
 
 type CharProps = {
-    children?: React.Node
-}
+	children?: React.Node,
+};
 
-export const getRemainingCharacters = (maxLength: number, value: string = '') => (parseInt(maxLength, 10) - value.length);
+export const getRemainingCharacters = (maxLength: number, value: string = '') =>
+	parseInt(maxLength, 10) - value.length;
 
-const CharCount = (props: CharProps) => <p data-swarm-textarea-char-count className="text--tiny" {...props} />;
+const CharCount = (props: CharProps) => (
+	<p data-swarm-textarea-char-count className="text--tiny" {...props} />
+);
 
 export default CharCount;

--- a/packages/swarm-components/src/shared/CharCount.test.jsx
+++ b/packages/swarm-components/src/shared/CharCount.test.jsx
@@ -1,8 +1,6 @@
 import React from 'react';
 import { shallow } from 'enzyme';
-import CharCount, {
-	getRemainingCharacters,
-} from './CharCount';
+import CharCount, { getRemainingCharacters } from './CharCount';
 
 describe('CharCount', () => {
 	const testCases = [
@@ -12,7 +10,7 @@ describe('CharCount', () => {
 
 	test.each(testCases)('Snapshot: %s', (description, element) => {
 		expect(shallow(element)).toMatchSnapshot();
-    });
+	});
 });
 
 describe('getRemainingCharacters', () => {

--- a/packages/swarm-components/src/shared/CharCount.test.jsx
+++ b/packages/swarm-components/src/shared/CharCount.test.jsx
@@ -1,0 +1,29 @@
+import React from 'react';
+import { shallow } from 'enzyme';
+import CharCount, {
+    getCharacterCount,
+} from './CharCount';
+
+describe('CharCount', () => {
+	const testCases = [
+		['Default', <CharCount key="0" />],
+		['with props', <CharCount key="1" className="foo" data-attribute="foo" />],
+	];
+
+	test.each(testCases)('Snapshot: %s', (description, element) => {
+		expect(shallow(element)).toMatchSnapshot();
+    });
+});
+
+describe('getCharacterCount', () => {
+	it('returns 0 when no argument provided', () => {
+		expect(getCharacterCount()).toEqual(0);
+	});
+
+	it('returns the length of a string', () => {
+		expect(getCharacterCount('')).toEqual(0);
+		expect(getCharacterCount('f')).toEqual(1);
+		expect(getCharacterCount('f234')).toEqual(4);
+		expect(getCharacterCount('ff ff ff')).toEqual(8);
+	});
+});

--- a/packages/swarm-components/src/shared/CharCount.test.jsx
+++ b/packages/swarm-components/src/shared/CharCount.test.jsx
@@ -1,11 +1,17 @@
 import React from 'react';
 import { shallow } from 'enzyme';
-import CharCount, { getRemainingCharacters } from './CharCount';
+import CharCount, {
+	getRemainingCharacters,
+	hasMaxLengthError,
+} from './CharCount';
 
 describe('CharCount', () => {
 	const testCases = [
 		['Default', <CharCount key="0" maxLength={80} />],
-		['Default with props', <CharCount key="1" className="foo" maxLength={80} data-attribute="foo" />],
+		[
+			'Default with props',
+			<CharCount key="1" className="foo" maxLength={80} data-attribute="foo" />,
+		],
 		['Value', <CharCount key="0" maxLength={80} value="some test value" />],
 	];
 
@@ -25,5 +31,25 @@ describe('getRemainingCharacters', () => {
 		expect(getRemainingCharacters(maxLength, 0)).toEqual(maxLength);
 		expect(getRemainingCharacters(maxLength, 6)).toEqual(4);
 		expect(getRemainingCharacters(maxLength, 15)).toEqual(-5);
+	});
+});
+
+describe('hasMaxLengthError', () => {
+	const maxLength = 10;
+
+	it('returns false when no charLength argument is provided', () => {
+		expect(hasMaxLengthError(maxLength)).toEqual(false);
+	});
+
+	it('returns false when value length is less than maxLength', () => {
+		expect(hasMaxLengthError(maxLength, 5)).toEqual(false);
+	});
+
+	it('returns false when value length is equal to maxLength', () => {
+		expect(hasMaxLengthError(maxLength, maxLength)).toEqual(false);
+	});
+
+	it('returns true when value length is greater than maxLength', () => {
+		expect(hasMaxLengthError(maxLength, 15)).toEqual(true);
 	});
 });

--- a/packages/swarm-components/src/shared/CharCount.test.jsx
+++ b/packages/swarm-components/src/shared/CharCount.test.jsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { shallow } from 'enzyme';
 import CharCount, {
-    getCharacterCount,
+	getRemainingCharacters,
 } from './CharCount';
 
 describe('CharCount', () => {
@@ -15,15 +15,18 @@ describe('CharCount', () => {
     });
 });
 
-describe('getCharacterCount', () => {
-	it('returns 0 when no argument provided', () => {
-		expect(getCharacterCount()).toEqual(0);
+describe('getRemainingCharacters', () => {
+	const maxLength = 10;
+
+	it('returns `maxLength` when no value provided', () => {
+		expect(getRemainingCharacters(maxLength)).toEqual(maxLength);
 	});
 
-	it('returns the length of a string', () => {
-		expect(getCharacterCount('')).toEqual(0);
-		expect(getCharacterCount('f')).toEqual(1);
-		expect(getCharacterCount('f234')).toEqual(4);
-		expect(getCharacterCount('ff ff ff')).toEqual(8);
+	it('returns the remaining character count', () => {
+		expect(getRemainingCharacters(maxLength, '')).toEqual(maxLength);
+		expect(getRemainingCharacters(maxLength, 'f')).toEqual(9);
+		expect(getRemainingCharacters(maxLength, 'f234')).toEqual(6);
+		expect(getRemainingCharacters(maxLength, 'ff ff ')).toEqual(4);
+		expect(getRemainingCharacters(maxLength, '000000000000000')).toEqual(-5);
 	});
 });

--- a/packages/swarm-components/src/shared/CharCount.test.jsx
+++ b/packages/swarm-components/src/shared/CharCount.test.jsx
@@ -4,8 +4,9 @@ import CharCount, { getRemainingCharacters } from './CharCount';
 
 describe('CharCount', () => {
 	const testCases = [
-		['Default', <CharCount key="0" />],
-		['with props', <CharCount key="1" className="foo" data-attribute="foo" />],
+		['Default', <CharCount key="0" maxLength={80} />],
+		['Default with props', <CharCount key="1" className="foo" maxLength={80} data-attribute="foo" />],
+		['Value', <CharCount key="0" maxLength={80} value="some test value" />],
 	];
 
 	test.each(testCases)('Snapshot: %s', (description, element) => {
@@ -21,10 +22,8 @@ describe('getRemainingCharacters', () => {
 	});
 
 	it('returns the remaining character count', () => {
-		expect(getRemainingCharacters(maxLength, '')).toEqual(maxLength);
-		expect(getRemainingCharacters(maxLength, 'f')).toEqual(9);
-		expect(getRemainingCharacters(maxLength, 'f234')).toEqual(6);
-		expect(getRemainingCharacters(maxLength, 'ff ff ')).toEqual(4);
-		expect(getRemainingCharacters(maxLength, '000000000000000')).toEqual(-5);
+		expect(getRemainingCharacters(maxLength, 0)).toEqual(maxLength);
+		expect(getRemainingCharacters(maxLength, 6)).toEqual(4);
+		expect(getRemainingCharacters(maxLength, 15)).toEqual(-5);
 	});
 });

--- a/packages/swarm-components/src/shared/__snapshots__/CharCount.test.jsx.snap
+++ b/packages/swarm-components/src/shared/__snapshots__/CharCount.test.jsx.snap
@@ -1,0 +1,16 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`CharCount Snapshot: Default 1`] = `
+<p
+  className="text--tiny"
+  data-swarm-textarea-char-count={true}
+/>
+`;
+
+exports[`CharCount Snapshot: with props 1`] = `
+<p
+  className="foo"
+  data-attribute="foo"
+  data-swarm-textarea-char-count={true}
+/>
+`;

--- a/packages/swarm-components/src/shared/__snapshots__/CharCount.test.jsx.snap
+++ b/packages/swarm-components/src/shared/__snapshots__/CharCount.test.jsx.snap
@@ -4,13 +4,27 @@ exports[`CharCount Snapshot: Default 1`] = `
 <p
   className="text--tiny"
   data-swarm-textarea-char-count={true}
-/>
+>
+  80
+</p>
 `;
 
-exports[`CharCount Snapshot: with props 1`] = `
+exports[`CharCount Snapshot: Default with props 1`] = `
 <p
   className="foo"
   data-attribute="foo"
   data-swarm-textarea-char-count={true}
-/>
+>
+  80
+</p>
+`;
+
+exports[`CharCount Snapshot: Value 1`] = `
+<p
+  className="text--tiny"
+  data-swarm-textarea-char-count={true}
+  value="some test value"
+>
+  80
+</p>
 `;

--- a/packages/swarm-components/src/utils/formUtils.js
+++ b/packages/swarm-components/src/utils/formUtils.js
@@ -1,0 +1,22 @@
+// @flow
+import type { TextInputProps } from '../TextInput';
+import type { TextareaProps } from '../Textarea';
+
+type FormFieldProps = TextInputProps | TextareaProps;
+
+/**
+ *
+ * @param {*} props
+ *
+ */
+export const getFormFieldState = (props: FormFieldProps): string => {
+	let state = 'default';
+
+	if (props.disabled) {
+		state = 'disabled';
+	} else if (props.error) {
+		state = 'error';
+    };
+
+    return state;
+};

--- a/packages/swarm-components/src/utils/formUtils.test.js
+++ b/packages/swarm-components/src/utils/formUtils.test.js
@@ -1,0 +1,16 @@
+import { getFormFieldState } from './formUtils';
+
+describe('getFormFieldState', () => {
+	it('returns disabled when props contain disabled=true', () => {
+		expect(getFormFieldState({disabled: true})).toEqual('disabled');
+		expect(getFormFieldState({disabled: true, error: true})).toEqual('disabled');
+	});
+
+	it('returns error when props contain error=true', () => {
+		expect(getFormFieldState({error: true})).toEqual('error');
+	});
+
+	it('returns default when props do not contain disabled or error', () => {
+		expect(getFormFieldState({})).toEqual('default');
+	});
+});

--- a/packages/swarm-docs/src/components/textInputExample.js
+++ b/packages/swarm-docs/src/components/textInputExample.js
@@ -8,6 +8,7 @@ const Example = () => {
   const [value5, setValue5] = React.useState('');
   const [value6, setValue6] = React.useState('abc');
   const [value7, setValue7] = React.useState('value');
+  const [value8, setValue8] = React.useState('value for a char counter');
 
   return (
     <>
@@ -61,6 +62,16 @@ const Example = () => {
         value={value7}
         onChange={(e) => setValue7(e.target.value)}
         iconShape="location-pin" />
+      <br/>
+      <label htmlFor="input8">maxLength (char count)</label>
+      <TextInput
+        id="input8"
+        name="input8"
+        value={value8}
+        onChange={(e) => setValue8(e.target.value)}
+        maxLength={60}
+        />
+      <br/>
     </>
   );
 };

--- a/packages/swarm-docs/src/components/textareaExample.js
+++ b/packages/swarm-docs/src/components/textareaExample.js
@@ -20,7 +20,7 @@ const TextareaExample = () => {
         value={value2}
         onChange={e => setValue2(e.target.value)}
         autosize
-        maxLength="200"
+        maxLength={200}
       />
     </>
   );


### PR DESCRIPTION
This PR creates a `swarm-components/src/shared` directory for `CharCount.jsx` which is then shared across `src/Textarea.jsx` and `src/TextInput.jsx`.

- Created unit tests for charcount. See `src/shared/CharCount.test.jsx`
- Updated `Textarea` to used methods and components from `shared/CharCount.jsx`
- Added `maxLength` prop support for TextInput and use the `shared/CharCount.jsx` component and methods.
- Updated `TextInput` unit tests
- Updated `TextInput` swarm-docs to add charcount example.