### PR TITLE
style: remove override which is causing gray-7 icon styling on buttons

### DIFF
--- a/packages/swarm-styles/lib/overrides.css
+++ b/packages/swarm-styles/lib/overrides.css
@@ -24,6 +24,11 @@
   color: var(--color-alert-red);
 }
 
+/* override fill from v1 with specific button colors */
+[data-swarm-button="primary"] .svg-icon {
+  fill: inherit;
+}
+
 /* override link colors */
 .link,
 a.link,

--- a/packages/swarm-styles/lib/overrides.css
+++ b/packages/swarm-styles/lib/overrides.css
@@ -24,11 +24,6 @@
   color: var(--color-alert-red);
 }
 
-/* override fill from v1 with specific button colors */
-[data-swarm-button] .svg-icon {
-  fill: inherit;
-}
-
 /* override link colors */
 .link,
 a.link,


### PR DESCRIPTION
This override is causing neutral button icons to be much darker than expected
![Screen Shot 2019-07-23 at 2 18 59 PM](https://user-images.githubusercontent.com/10870371/61736898-17861780-ad55-11e9-8ccc-881ff7f75d08.png)
![Screen Shot 2019-07-23 at 2 19 08 PM](https://user-images.githubusercontent.com/10870371/61736899-17861780-ad55-11e9-8165-0b535f070031.png)
