### PR TITLE
Interface to type

### DIFF
--- a/packages/swarm-components/src/Button.tsx
+++ b/packages/swarm-components/src/Button.tsx
@@ -3,7 +3,7 @@ import * as React from 'react';
 import { Icon } from './Icon';
 import { getButtonType, getSwarmSize, getIconPosition } from './utils/buttonUtils';
 
-export interface ButtonProps {
+export type ButtonProps = {
 	/**
 	 * The bordered button
 	 */

--- a/packages/swarm-components/src/Checkbox.tsx
+++ b/packages/swarm-components/src/Checkbox.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react';
 import { Icon } from './Icon';
 
-export interface Props {
+export type Props = {
 	/**
 	 * Whether the box should be checked.
 	 */

--- a/packages/swarm-components/src/Dropdown.tsx
+++ b/packages/swarm-components/src/Dropdown.tsx
@@ -21,7 +21,7 @@ const RECT_DEFAULTS: DOMRect = {
 	toJSON: () => null
 }
 
-interface MenuCtx {
+type MenuCtx = {
 	isOpen: boolean,
 	selectionIndex: number,
 	closingWithClick: boolean,
@@ -68,7 +68,7 @@ const getInitialState = (): MenuCtx => ({
 	dispatch: ({}: any) => null
 });
 
-interface Action {
+type Action = {
 	type: 'OPEN' | 'CLOSE' | 'SET_SELECTION_INDEX' | 'CLEAR_SELECTION_INDEX' | 'UPDATE_RECT' | 'SET_IS_KEYBOARD_USER',
 	payload?: any
 };
@@ -122,7 +122,7 @@ const Menu: ({ children }) => any| React.ReactElement<any> = ({ children }) => {
 };
 
 // //////////////////////////////////////////////////////////////////////
-interface MenuButtonProps {
+type MenuButtonProps = {
 	onClick: () => void,
 	onKeyDown: () => void,
 	onMouseDown: () => void,
@@ -184,7 +184,7 @@ const MenuButton = React.forwardRef(
 	}
 );
 
-interface MenuItemProps {
+type MenuItemProps = {
 	onSelect: () => void,
 	onClick?: () => void,
 	role?: string,
@@ -267,7 +267,7 @@ const MenuItem = React.forwardRef<HTMLUnknownElement, MenuItemProps>((props, ref
 const k = () => {};
 
 // //////////////////////////////////////////////////////////////////////
-interface MenuLinkProps {
+type MenuLinkProps = {
 	onKeyDown?: () => void,
 	onClick?: () => void,
 	component?: any,
@@ -398,7 +398,7 @@ const getFocusableMenuChildren = (children, types) => {
 	return focusable;
 };
 
-interface MenuListImplProps {
+type MenuListImplProps = {
 	focusableChildrenTypes: Array<any>,
 	children: React.ReactElement,
 	onKeyDown: () => void,
@@ -491,7 +491,7 @@ const MenuListImpl = React.forwardRef<HTMLDivElement, MenuListImplProps>((props,
 );
 
 type zIndexType = number | "-moz-initial" | "inherit" | "initial" | "revert" | "unset" | "auto" | undefined;
-interface StyleShape {
+type StyleShape = {
 	minWidth?: number
 	left?: string | number,
 	top?: string | number,

--- a/packages/swarm-components/src/Icon.tsx
+++ b/packages/swarm-components/src/Icon.tsx
@@ -6,7 +6,7 @@ function toPascalCase(s: string) {
 	return capitalized.replace(/-(\w)/g, g => g[1].toUpperCase());
 }
 
-interface Props {
+type Props = {
 	shape: string,
 	color?: string
 };

--- a/packages/swarm-components/src/LinkButton.tsx
+++ b/packages/swarm-components/src/LinkButton.tsx
@@ -3,9 +3,8 @@ import { Icon } from './Icon';
 import { ButtonProps } from './Button';
 import { getButtonType, getSwarmSize, getIconPosition } from './utils/buttonUtils';
 
-export interface LinkButtonProps extends ButtonProps {};
 
-const LinkButton = (props: LinkButtonProps): React.AnchorHTMLAttributes<LinkButtonProps> => {
+const LinkButton = (props: ButtonProps): React.AnchorHTMLAttributes<ButtonProps> => {
 	// destructuring to not pass invalid attributes to node
 	const {
 		icon,

--- a/packages/swarm-components/src/NumericalInput.tsx
+++ b/packages/swarm-components/src/NumericalInput.tsx
@@ -3,7 +3,7 @@ import { Icon } from './Icon';
 
 type Value = number | null | undefined;
 
-interface Props {
+type Props = {
 	/**
 	 * Classname of wrapper, specified because it is not applied with other
 	 */

--- a/packages/swarm-components/src/Radio.tsx
+++ b/packages/swarm-components/src/Radio.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 
-interface Props {
+type Props = {
 	/**
 	 * Whether the radio button is checked.
 	 */

--- a/packages/swarm-components/src/Select.tsx
+++ b/packages/swarm-components/src/Select.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react';
 import { ArrowDown } from '@meetup/swarm-icons/lib/components/solid';
 
-interface Props {
+type Props = {
 	/**
 	 * Whether the select menu is disabled.
 	 */

--- a/packages/swarm-components/src/TextInput.tsx
+++ b/packages/swarm-components/src/TextInput.tsx
@@ -13,7 +13,7 @@ const ICON_SIZES = Object.freeze({
 	XXL: 'xxl',
 });
 
-interface TextInputProps {
+type TextInputProps = {
 	/**
 	 * Whether the input should be interactive.
 	 */

--- a/packages/swarm-components/src/Textarea.tsx
+++ b/packages/swarm-components/src/Textarea.tsx
@@ -5,7 +5,7 @@ import { CharCount, hasMaxLengthError } from './shared/CharCount';
 
 import { getFormFieldState } from './utils/formUtils';
 
-interface Props {
+type Props = {
 	/**
 	 * Resizes the height based on content
 	 */
@@ -31,8 +31,6 @@ interface Props {
 	 */
 	maxLength?: number,
 };
-
-type State = {};
 
 const Textarea = (props: Props): React.ReactElement => {
 	// maxLength is removed because we want to allow for typing over the character limit

--- a/packages/swarm-components/src/Toast.tsx
+++ b/packages/swarm-components/src/Toast.tsx
@@ -4,7 +4,7 @@ import { ToasterContext } from './Toaster';
 import { Button } from './Button';
 import { CheckCircledSelected, CloseCircledSelected, WarningCircledSelected } from '@meetup/swarm-icons/lib/components/large';
 
-export interface ToastProps {
+export type ToastProps = {
   /**
    * The status of the toast displayed. Options are success, error, warning, & default
    */

--- a/packages/swarm-components/src/Toaster.tsx
+++ b/packages/swarm-components/src/Toaster.tsx
@@ -7,7 +7,7 @@ const removeToast = (toasts: Array<any>, id: string) => {
   return [...toasts.filter(t => t.id !== id)];
 };
 
-interface ToasterContextInterface {
+type ToasterContextInterface = {
   toasts: Array<any>,
   addToast: (i: any) => void,
   removeToast: (i: any) => void,

--- a/packages/swarm-components/src/utils/buttonUtils.ts
+++ b/packages/swarm-components/src/utils/buttonUtils.ts
@@ -1,7 +1,6 @@
 import { ButtonProps } from '../Button';
-import { LinkButtonProps } from '../LinkButton';
 
-type Props = ButtonProps | LinkButtonProps;
+type Props = ButtonProps;
 
 /**
  *

--- a/packages/swarm-icons/package.json
+++ b/packages/swarm-icons/package.json
@@ -22,7 +22,7 @@
   "scripts": {
     "clean:components": "rm -f src/components/**/*.jsx",
     "clean:icons": "rm src/icons/**/*.svg",
-    "generate": "npx svgo src/icons/**/*.svg && yarn clean:components && src/build.js --f=solid && src/build.js --f=line && src/build.js --f=large",
+    "generate": "npm i -g now@16.2.0 && npx svgo src/icons/**/*.svg && yarn clean:components && src/build.js --f=solid && src/build.js --f=line && src/build.js --f=large",
     "build": "yarn generate && npx babel src --out-dir lib --ignore 'src/**/*.test.js','src/build.js'"
   },
   "bugs": {


### PR DESCRIPTION
Convert declarations from `interface` to `type` for `react-docgen` support